### PR TITLE
added htlc index in update_commit message

### DIFF
--- a/communications/low/02-wire-protocol.md
+++ b/communications/low/02-wire-protocol.md
@@ -428,6 +428,8 @@ to a failed connection), to reduce this risk.
     message update_commit {
       // Signature for your new commitment tx.
       required signature sig = 1;
+      // Which HTLC (index into current HTLCs in the order offered)
+      required uint32 index = 2;
     }
 
 ### update_revocation message format ###


### PR DESCRIPTION
Hey Rusty,

I think the `update_commit` message is missing an `index` field indicating what htlcs are included in the signature. I don't see how the other party could guess it, but I may have missed something ?

Cheers,
Pierre