### PR TITLE
Add a test for 'fundchannel_start' crash on deconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- JSON API: `close` optional arguments have changed: it now defaults to unilateral close after 48 hours.
 - build: now requires `python3-mako` to be installed, i.e. `sudo apt-get install python3-mako`
 - plugins: if the config directory has a `plugins` subdirectory, those are loaded.
 - plugins: a new notification type `invoice_payment` (sent when an invoice is paid) has been added

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -367,6 +367,7 @@ static enum channel_add_err add_htlc(struct channel *channel,
 	enum side sender = htlc_state_owner(state), recipient = !sender;
 	const struct htlc **committed, **adding, **removing;
 	const struct channel_view *view;
+	u32 min_concurrent_htlcs;
 
 	htlc = tal(tmpctx, struct htlc);
 
@@ -443,8 +444,16 @@ static enum channel_add_err add_htlc(struct channel *channel,
 	 *     HTLCs to its local commitment transaction...
 	 *     - SHOULD fail the channel.
 	 */
+	/* Also we should not add more htlc's than sender or recipient
+	 * configured.  This mitigates attacks in which a peer can force the
+	 * funder of the channel to pay unnecessary onchain fees during a fee
+	 * spike with large commitment transactions.
+	 */
+	min_concurrent_htlcs = channel->config[recipient].max_accepted_htlcs;
+	if (min_concurrent_htlcs > channel->config[sender].max_accepted_htlcs)
+		min_concurrent_htlcs = channel->config[sender].max_accepted_htlcs;
 	if (tal_count(committed) - tal_count(removing) + tal_count(adding)
-	    > channel->config[recipient].max_accepted_htlcs) {
+	    > min_concurrent_htlcs) {
 		return CHANNEL_ERR_TOO_MANY_HTLCS;
 	}
 

--- a/doc/lightning-close.7
+++ b/doc/lightning-close.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-close
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 04/30/2018
+.\"      Date: 08/08/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-CLOSE" "7" "04/30/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-CLOSE" "7" "08/08/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -31,29 +31,32 @@
 lightning-close \- Command for closing channels with direct peers
 .SH "SYNOPSIS"
 .sp
-\fBclose\fR \fIid\fR [\fIforce\fR] [\fItimeout\fR]
+\fBclose\fR \fIid\fR [\fIunilateraltimeout\fR]
 .SH "DESCRIPTION"
 .sp
-The \fBclose\fR RPC command attempts to close the channel cooperatively with the peer\&. If the given \fIid\fR is a peer ID (66 hex digits as a string), then it applies to the active channel of the direct peer corresponding to the given peer ID\&. If the given \fIid\fR is a channel ID (64 hex digits as a string, or the short channel ID \fIblockheight:txindex:outindex\fR form), then it applies to that channel\&.
+The \fBclose\fR RPC command attempts to close the channel cooperatively with the peer, or unilaterally after \fIunilateraltimeout\fR\&.
 .sp
-The \fBclose\fR command will time out and return with an error when the number of seconds specified in \fItimeout\fR is reached\&. If unspecified, it times out in 30 seconds\&.
+If the given \fIid\fR is a peer ID (66 hex digits as a string), then it applies to the active channel of the direct peer corresponding to the given peer ID\&. If the given \fIid\fR is a channel ID (64 hex digits as a string, or the short channel ID \fIblockheight:txindex:outindex\fR form), then it applies to that channel\&.
 .sp
-The \fIforce\fR argument, if the JSON value \fItrue\fR, will cause the channel to be unilaterally closed when the timeout is reached\&. If so, timeout will not cause an error, but instead cause the channel to be failed and put onchain unilaterally\&. Unilateral closes will lead to your funds getting locked according to the \fIto_self_delay\fR parameter of the peer\&.
+If \fIunilateraltimeout\fR is not zero, the \fBclose\fR command will unilaterally close the channel when that number of seconds is reached\&. If \fIunilateraltimeout\fR is zero, then the \fBclose\fR command will wait indefinitely until the peer is online and can negotiate a mutual close\&. The default is 2 days (172800 seconds)\&.
 .sp
-Normally the peer needs to be live and connected in order to negotiate a mutual close\&. Forcing a unilateral close can be used if you suspect you can no longer contact the peer\&.
+The peer needs to be live and connected in order to negotiate a mutual close\&. The default of unilaterally closing after 48 hours is usually a reasonable indication that you can no longer contact the peer\&.
+.SH "NOTES"
+.sp
+Prior to 0\&.7\&.2, \fBclose\fR took two parameters: \fIforce\fR and \fItimeout\fR\&. \fItimeout\fR was the number of seconds before \fIforce\fR took effect (default, 30), and \fIforce\fR determined whether the result was a unilateral close or an RPC error (default)\&. Even after the timeout, the channel would be closed if the peer reconnected\&.
 .SH "RETURN VALUE"
 .sp
 On success, an object with fields \fItx\fR and \fItxid\fR containing the closing transaction are returned\&. It will also have a field \fItype\fR which is either the JSON string \fImutual\fR or the JSON string \fIunilateral\fR\&. A \fImutual\fR close means that we could negotiate a close with the peer, while a \fIunilateral\fR close means that the \fIforce\fR flag was set and we had to close the channel without waiting for the counterparty\&.
 .sp
-A unilateral close may still occur with \fIforce\fR set to \fIfalse\fR if the peer did not behave correctly during the close negotiation\&.
+A unilateral close may still occur at any time if the peer did not behave correctly during the close negotiation\&.
 .sp
 Unilateral closes will return your funds after a delay\&. The delay will vary based on the peer \fIto_self_delay\fR setting, not your own setting\&.
-.sp
-On failure, if \fBclose\fR failed due to timing out with \fIforce\fR argument \fIfalse\fR, the channel will still eventually close once we have contacted the peer\&.
 .SH "AUTHOR"
 .sp
 ZmnSCPxj <ZmnSCPxj@protonmail\&.com> is mainly responsible\&.
 .SH "SEE ALSO"
+.sp
+lightning\-disconnect(7), lightning\-fundchannel(7)
 .SH "RESOURCES"
 .sp
 Main web site: https://github\&.com/ElementsProject/lightning

--- a/doc/lightning-close.7.txt
+++ b/doc/lightning-close.7.txt
@@ -8,13 +8,14 @@ lightning-close - Command for closing channels with direct peers
 
 SYNOPSIS
 --------
-*close* 'id' ['force'] ['timeout']
+*close* 'id' ['unilateraltimeout']
 
 DESCRIPTION
 -----------
 
 The *close* RPC command attempts to close the channel cooperatively
-with the peer.
+with the peer, or unilaterally after 'unilateraltimeout'.
+
 If the given 'id' is a peer ID (66 hex digits as a string), then
 it applies to the active channel of the direct peer corresponding to
 the given peer ID.
@@ -22,21 +23,25 @@ If the given 'id' is a channel ID (64 hex digits as a string, or
 the short channel ID 'blockheight:txindex:outindex' form), then it
 applies to that channel.
 
-The *close* command will time out and return with an error when the
-number of seconds specified in 'timeout' is reached.
-If unspecified, it times out in 30 seconds.
+If 'unilateraltimeout' is not zero, the *close* command will
+unilaterally close the channel when that number of seconds is reached.
+If 'unilateraltimeout' is zero, then the *close* command will wait
+indefinitely until the peer is online and can negotiate a mutual
+close.  The default is 2 days (172800 seconds).
 
-The 'force' argument, if the JSON value 'true', will cause the
-channel to be unilaterally closed when the timeout is reached.
-If so, timeout will not cause an error, but instead cause the
-channel to be failed and put onchain unilaterally.
-Unilateral closes will lead to your funds getting locked according
-to the 'to_self_delay' parameter of the peer.
-
-Normally the peer needs to be live and connected in order to negotiate
-a mutual close.
-Forcing a unilateral close can be used if you suspect you can no longer
+The peer needs to be live and connected in order to negotiate
+a mutual close.  The default of unilaterally closing after 48 hours
+is usually a reasonable indication that you can no longer
 contact the peer.
+
+NOTES
+-----
+
+Prior to 0.7.2, *close* took two parameters: 'force' and 'timeout'.
+'timeout' was the number of seconds before 'force' took effect
+(default, 30), and 'force' determined whether the result was a
+unilateral close or an RPC error (default).  Even after
+the timeout, the channel would be closed if the peer reconnected.
 
 RETURN VALUE
 ------------
@@ -50,16 +55,12 @@ peer, while a 'unilateral' close means that the 'force' flag was
 set and we had to close the channel without waiting for the
 counterparty.
 
-A unilateral close may still occur with 'force' set to 'false' if
+A unilateral close may still occur at any time if
 the peer did not behave correctly during the close negotiation.
 
 Unilateral closes will return your funds after a delay.
 The delay will vary based on the peer 'to_self_delay' setting, not
 your own setting.
-
-On failure, if *close* failed due to timing out with 'force'
-argument 'false', the channel will still eventually close once
-we have contacted the peer.
 
 AUTHOR
 ------
@@ -67,7 +68,7 @@ ZmnSCPxj <ZmnSCPxj@protonmail.com> is mainly responsible.
 
 SEE ALSO
 --------
-
+lightning-disconnect(7), lightning-fundchannel(7)
 
 RESOURCES
 ---------

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -2,12 +2,12 @@
 .\"     Title: lightningd-config
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 08/04/2019
+.\"      Date: 08/09/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNINGD\-CONFIG" "5" "08/04/2019" "\ \&" "\ \&"
+.TH "LIGHTNINGD\-CONFIG" "5" "08/09/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -255,6 +255,11 @@ Limits on what onchain fee range we\(cqll allow when a node opens a channel with
 \fIestimatesmartfee 2\fR\&. If they\(cqre outside this range, we abort their opening attempt\&. Note that
 \fBcommit\-fee\-max\fR
 can (should!) be greater than 100\&.
+.RE
+.PP
+\fBmax\-concurrent\-htlcs\fR=\fIINTEGER\fR
+.RS 4
+Number of HTLCs one channel can handle concurrently in each direction\&. Should be between 1 and 483 (default 30)\&.
 .RE
 .PP
 \fBcltv\-delta\fR=\fIBLOCKS\fR

--- a/doc/lightningd-config.5.txt
+++ b/doc/lightningd-config.5.txt
@@ -205,6 +205,10 @@ Lightning channel and HTLC options
     they're outside this range, we abort their opening attempt.  Note
     that *commit-fee-max* can (should!) be greater than 100.
 
+*max-concurrent-htlcs*='INTEGER'::
+    Number of HTLCs one channel can handle concurrently in each direction.
+    Should be between 1 and 483 (default 30).
+
 *cltv-delta*='BLOCKS'::
     The number of blocks between incoming payments and outgoing payments:
     this needs to be enough to make sure that if we have to, we can close

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -42,6 +42,9 @@ struct config {
 	u32 fee_base;
 	u32 fee_per_satoshi;
 
+	/* htlcs per channel */
+	u32 max_concurrent_htlcs;
+
 	/* How long between changing commit and sending COMMIT message. */
 	u32 commit_time_ms;
 

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -835,13 +835,7 @@ static void channel_config(struct lightningd *ld,
 	 */
 	 ours->to_self_delay = ld->config.locktime_blocks;
 
-	 /* BOLT #2:
-	  *
-	  * The receiving node MUST fail the channel if:
-	  *...
-	  *   - `max_accepted_htlcs` is greater than 483.
-	  */
-	 ours->max_accepted_htlcs = 483;
+	 ours->max_accepted_htlcs = ld->config.max_concurrent_htlcs;
 
 	 /* This is filled in by lightning_openingd, for consistency. */
 	 ours->channel_reserve = AMOUNT_SAT(UINT64_MAX);

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -99,7 +99,7 @@ static void uncommitted_channel_disconnect(struct uncommitted_channel *uc,
 	u8 *msg = towire_connectctl_peer_disconnected(tmpctx, &uc->peer->id);
 	log_info(uc->log, "%s", desc);
 	subd_send_msg(uc->peer->ld->connectd, msg);
-	if (uc->fc)
+	if (uc->fc && uc->fc->cmd)
 		was_pending(command_fail(uc->fc->cmd, LIGHTNINGD, "%s", desc));
 	notify_disconnect(uc->peer->ld, &uc->peer->id);
 }

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -13,7 +13,7 @@ import unittest
 
 @unittest.skipIf(not DEVELOPER, "Too slow without --dev-bitcoind-poll")
 def test_closing(node_factory, bitcoind):
-    l1, l2 = node_factory.line_graph(2)
+    l1, l2 = node_factory.line_graph(2, opts={'allow-deprecated-apis': True})
     chan = l1.get_channel_scid(l2)
 
     l1.pay(l2, 200000000)
@@ -98,7 +98,7 @@ def test_closing(node_factory, bitcoind):
 
 
 def test_closing_while_disconnected(node_factory, bitcoind):
-    l1, l2 = node_factory.line_graph(2, opts={'may_reconnect': True})
+    l1, l2 = node_factory.line_graph(2, opts={'may_reconnect': True, 'allow-deprecated-apis': True})
     chan = l1.get_channel_scid(l2)
 
     l1.pay(l2, 200000000)
@@ -147,7 +147,7 @@ def test_closing_id(node_factory):
 
 @unittest.skipIf(not DEVELOPER, "needs dev-rescan-outputs")
 def test_closing_torture(node_factory, executor, bitcoind):
-    l1, l2 = node_factory.get_nodes(2)
+    l1, l2 = node_factory.get_nodes(2, opts={'allow-deprecated-apis': True})
     amount = 10**6
 
     # Before the fix was applied, 15 would often pass.
@@ -197,7 +197,7 @@ def test_closing_torture(node_factory, executor, bitcoind):
 
 @unittest.skipIf(SLOW_MACHINE and VALGRIND, "slow test")
 def test_closing_different_fees(node_factory, bitcoind, executor):
-    l1 = node_factory.get_node()
+    l1 = node_factory.get_node(options={'allow-deprecated-apis': True})
 
     # Default feerate = 15000/7500/1000
     # It will start at the second number, accepting anything above the first.
@@ -215,7 +215,7 @@ def test_closing_different_fees(node_factory, bitcoind, executor):
     peers = []
     for feerate in feerates:
         for amount in amounts:
-            p = node_factory.get_node(feerates=feerate)
+            p = node_factory.get_node(feerates=feerate, options={'allow-deprecated-apis': True})
             p.feerate = feerate
             p.amount = amount
             l1.rpc.connect(p.info['id'], 'localhost', p.port)
@@ -265,7 +265,7 @@ def test_closing_negotiation_reconnect(node_factory, bitcoind):
     disconnects = ['-WIRE_CLOSING_SIGNED',
                    '@WIRE_CLOSING_SIGNED',
                    '+WIRE_CLOSING_SIGNED']
-    l1 = node_factory.get_node(disconnect=disconnects, may_reconnect=True)
+    l1 = node_factory.get_node(disconnect=disconnects, may_reconnect=True, options={'allow-deprecated-apis': True})
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -920,6 +920,7 @@ def test_funding_cancel_race(node_factory, bitcoind, executor):
 def test_funding_external_wallet(node_factory, bitcoind):
     l1 = node_factory.get_node()
     l2 = node_factory.get_node()
+    l3 = node_factory.get_node()
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     assert(l1.rpc.listpeers()['peers'][0]['id'] == l2.info['id'])
@@ -965,6 +966,11 @@ def test_funding_external_wallet(node_factory, bitcoind):
         node.daemon.wait_for_log(r'State changed from CHANNELD_AWAITING_LOCKIN to CHANNELD_NORMAL')
         channel = node.rpc.listpeers()['peers'][0]['channels'][0]
         assert amount * 1000 == channel['msatoshi_total']
+
+    # Test that we don't crash if peer disconnects after fundchannel_start
+    l2.connect(l3)
+    l2.rpc.fundchannel_start(l3.info["id"], amount)
+    l3.rpc.close(l2.info["id"])
 
 
 def test_lockin_between_restart(node_factory, bitcoind):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -577,7 +577,8 @@ def test_shutdown_reconnect(node_factory):
                    '@WIRE_SHUTDOWN',
                    '+WIRE_SHUTDOWN']
     l1 = node_factory.get_node(disconnect=disconnects,
-                               may_reconnect=True)
+                               may_reconnect=True,
+                               options={'allow-deprecated-apis': True})
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
@@ -637,7 +638,7 @@ def test_reconnect_remote_sends_no_sigs(node_factory):
 
 
 def test_shutdown_awaiting_lockin(node_factory, bitcoind):
-    l1 = node_factory.get_node()
+    l1 = node_factory.get_node(options={'allow-deprecated-apis': True})
     l2 = node_factory.get_node(options={'funding-confirms': 3})
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -1128,7 +1129,7 @@ def test_channel_reenable(node_factory):
 
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
 def test_update_fee(node_factory, bitcoind):
-    l1, l2 = node_factory.line_graph(2, fundchannel=True)
+    l1, l2 = node_factory.line_graph(2, fundchannel=True, opts={'allow-deprecated-apis': True})
     chanid = l1.get_channel_scid(l2)
 
     # Make l1 send out feechange.
@@ -1312,7 +1313,7 @@ def test_forget_channel(node_factory):
 
 
 def test_peerinfo(node_factory, bitcoind):
-    l1, l2 = node_factory.line_graph(2, fundchannel=False, opts={'may_reconnect': True})
+    l1, l2 = node_factory.line_graph(2, fundchannel=False, opts={'may_reconnect': True, 'allow-deprecated-apis': True})
     lfeatures = 'aa'
     # Gossiping but no node announcement yet
     assert l1.rpc.getpeer(l2.info['id'])['connected']

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1165,7 +1165,7 @@ def test_forward_local_failed_stats(node_factory, bitcoind, executor):
     disconnects = ['-WIRE_UPDATE_FAIL_HTLC', 'permfail']
 
     l1 = node_factory.get_node()
-    l2 = node_factory.get_node(options={'allow-deprecated-apis': True})
+    l2 = node_factory.get_node()
     l3 = node_factory.get_node()
     l4 = node_factory.get_node(disconnect=disconnects)
     l5 = node_factory.get_node()
@@ -1202,7 +1202,7 @@ def test_forward_local_failed_stats(node_factory, bitcoind, executor):
     payment_hash = l3.rpc.invoice(amount, "first", "desc")['payment_hash']
     route = l1.rpc.getroute(l3.info['id'], amount, 1)['route']
 
-    l2.rpc.close(c23, True, 0)
+    l2.rpc.close(c23, 1)
 
     with pytest.raises(RpcError):
         l1.rpc.sendpay(route, payment_hash)
@@ -1824,7 +1824,7 @@ def test_setchannelfee_state(node_factory, bitcoind):
 
     l0 = node_factory.get_node(options={'fee-base': DEF_BASE, 'fee-per-satoshi': DEF_PPM})
     l1 = node_factory.get_node(options={'fee-base': DEF_BASE, 'fee-per-satoshi': DEF_PPM})
-    l2 = node_factory.get_node(options={'fee-base': DEF_BASE, 'fee-per-satoshi': DEF_PPM, 'allow-deprecated-apis': True})
+    l2 = node_factory.get_node(options={'fee-base': DEF_BASE, 'fee-per-satoshi': DEF_PPM})
 
     # connection and funding
     l0.rpc.connect(l1.info['id'], 'localhost', l1.port)
@@ -1849,7 +1849,7 @@ def test_setchannelfee_state(node_factory, bitcoind):
     # Disconnect and unilaterally close from l2 to l1
     l2.rpc.disconnect(l1.info['id'], force=True)
     l1.rpc.disconnect(l2.info['id'], force=True)
-    result = l2.rpc.close(scid, True, 0)
+    result = l2.rpc.close(scid, 1)
     assert result['type'] == 'unilateral'
 
     # wait for l1 to see unilateral close via bitcoin network

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1165,7 +1165,7 @@ def test_forward_local_failed_stats(node_factory, bitcoind, executor):
     disconnects = ['-WIRE_UPDATE_FAIL_HTLC', 'permfail']
 
     l1 = node_factory.get_node()
-    l2 = node_factory.get_node()
+    l2 = node_factory.get_node(options={'allow-deprecated-apis': True})
     l3 = node_factory.get_node()
     l4 = node_factory.get_node(disconnect=disconnects)
     l5 = node_factory.get_node()
@@ -1824,7 +1824,7 @@ def test_setchannelfee_state(node_factory, bitcoind):
 
     l0 = node_factory.get_node(options={'fee-base': DEF_BASE, 'fee-per-satoshi': DEF_PPM})
     l1 = node_factory.get_node(options={'fee-base': DEF_BASE, 'fee-per-satoshi': DEF_PPM})
-    l2 = node_factory.get_node(options={'fee-base': DEF_BASE, 'fee-per-satoshi': DEF_PPM})
+    l2 = node_factory.get_node(options={'fee-base': DEF_BASE, 'fee-per-satoshi': DEF_PPM, 'allow-deprecated-apis': True})
 
     # connection and funding
     l0.rpc.connect(l1.info['id'], 'localhost', l1.port)

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -325,6 +325,9 @@ char *json_strdup(const tal_t *ctx UNNEEDED, const char *buffer UNNEEDED, const 
 /* Generated stub for json_stream_success */
 struct json_stream *json_stream_success(struct command *cmd UNNEEDED)
 { fprintf(stderr, "json_stream_success called!\n"); abort(); }
+/* Generated stub for json_to_bool */
+bool json_to_bool(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED, bool *b UNNEEDED)
+{ fprintf(stderr, "json_to_bool called!\n"); abort(); }
 /* Generated stub for json_tok_bin_from_hex */
 u8 *json_tok_bin_from_hex(const tal_t *ctx UNNEEDED, const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED)
 { fprintf(stderr, "json_tok_bin_from_hex called!\n"); abort(); }


### PR DESCRIPTION
This fails before the commit, passes after.